### PR TITLE
Fix invalid syntax

### DIFF
--- a/unwatch.rb
+++ b/unwatch.rb
@@ -1,6 +1,6 @@
 require "language/go"
 
-class unwatch < Formula
+class Unwatch < Formula
   homepage "https://github.com/sona-tar/github-unwatch-cli"
   url  "https://github.com/sona-tar/github-unwatch-cli", :using => :git, :tag => "0.0.1"
   head "https://github.com/sona-tar/github-unwatch-cli", :using => :git, :branch => "master"


### PR DESCRIPTION
I tried to install ghs, but failed.

```
$ brew install sonatard/tools/ghs
==> Tapping sonatard/tools
Cloning into '/Users/sasaplus1/Homebrew/Library/Taps/sonatard/homebrew-tools'...
remote: Counting objects: 6, done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 6 (delta 2), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Error: Invalid formula: /Users/sasaplus1/Homebrew/Library/Taps/sonatard/homebrew-tools/unwatch.rb
/Users/sasaplus1/Homebrew/Library/Taps/sonatard/homebrew-tools/unwatch.rb:3: class/module name must be CONSTANT
class unwatch < Formula
               ^
               Error: Cannot tap sonatard/tools: invalid syntax in tap!
```